### PR TITLE
Get wechat official account share ticket

### DIFF
--- a/WECHAT_SHARE_README.md
+++ b/WECHAT_SHARE_README.md
@@ -1,0 +1,241 @@
+# 微信公众号分享小卡片 Ticket 获取服务
+
+本项目提供了一个完整的解决方案来获取微信公众号分享小卡片所需的 `jsapi_ticket`，并实现自定义分享功能。
+
+## 功能特性
+
+- 🎯 自动获取和缓存 `access_token`
+- 🎫 自动获取和缓存 `jsapi_ticket`
+- ✍️ 自动生成 JS-SDK 签名
+- 🔄 智能缓存机制，避免频繁请求
+- 🌐 RESTful API 接口
+- 📱 完整的前端示例
+
+## 快速开始
+
+### 1. 安装依赖
+
+```bash
+npm install
+```
+
+### 2. 配置微信公众号信息
+
+编辑 `wechat-ticket-server.js` 文件，替换以下配置：
+
+```javascript
+const config = {
+    appId: 'YOUR_APPID',        // 替换为您的公众号AppID
+    appSecret: 'YOUR_APPSECRET', // 替换为您的公众号AppSecret
+};
+```
+
+### 3. 启动服务器
+
+```bash
+# 生产环境
+npm start
+
+# 开发环境（自动重启）
+npm run dev
+```
+
+服务器将在 `http://localhost:3000` 启动。
+
+### 4. 配置微信公众号
+
+1. 登录微信公众号平台
+2. 进入 "公众号设置" -> "功能设置"
+3. 配置 "JS接口安全域名"，填入您网站的域名（不包含协议和端口）
+
+## API 接口
+
+### 获取 Access Token
+
+```
+GET /api/wechat/access_token
+```
+
+**响应示例：**
+```json
+{
+  "success": true,
+  "data": {
+    "access_token": "ACCESS_TOKEN",
+    "expires_at": 1640995200000
+  }
+}
+```
+
+### 获取 JSApi Ticket
+
+```
+GET /api/wechat/jsapi_ticket
+```
+
+**响应示例：**
+```json
+{
+  "success": true,
+  "data": {
+    "jsapi_ticket": "JSAPI_TICKET",
+    "expires_at": 1640995200000
+  }
+}
+```
+
+### 获取 JS-SDK 配置
+
+```
+POST /api/wechat/js_config
+Content-Type: application/json
+
+{
+  "url": "https://your-domain.com/page"
+}
+```
+
+**响应示例：**
+```json
+{
+  "success": true,
+  "data": {
+    "appId": "YOUR_APPID",
+    "timestamp": "1640995200",
+    "nonceStr": "randomstring",
+    "signature": "signature_hash",
+    "jsApiList": [
+      "updateAppMessageShareData",
+      "updateTimelineShareData"
+    ]
+  }
+}
+```
+
+## 前端使用示例
+
+### 1. 引入微信 JS-SDK
+
+```html
+<script src="https://res.wx.qq.com/open/js/jweixin-1.6.0.js"></script>
+```
+
+### 2. 获取配置并初始化
+
+```javascript
+// 获取JS-SDK配置
+const response = await fetch('/api/wechat/js_config', {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+        url: window.location.href.split('#')[0]
+    })
+});
+
+const result = await response.json();
+const config = result.data;
+
+// 配置微信JS-SDK
+wx.config({
+    debug: false,
+    appId: config.appId,
+    timestamp: config.timestamp,
+    nonceStr: config.nonceStr,
+    signature: config.signature,
+    jsApiList: config.jsApiList
+});
+```
+
+### 3. 配置分享内容
+
+```javascript
+wx.ready(function () {
+    // 分享给朋友
+    wx.updateAppMessageShareData({
+        title: '分享标题',
+        desc: '分享描述',
+        link: '分享链接',
+        imgUrl: '缩略图链接',
+        success: function () {
+            console.log('分享配置成功');
+        }
+    });
+    
+    // 分享到朋友圈
+    wx.updateTimelineShareData({
+        title: '分享标题',
+        link: '分享链接',
+        imgUrl: '缩略图链接',
+        success: function () {
+            console.log('朋友圈分享配置成功');
+        }
+    });
+});
+```
+
+## 测试页面
+
+打开 `wechat-share-example.html` 文件可以测试分享功能：
+
+1. 在浏览器中打开 `wechat-share-example.html`
+2. 确保服务器已启动
+3. 点击 "测试获取Ticket" 验证服务是否正常
+4. 填写分享信息
+5. 点击 "初始化微信分享"
+6. 在微信中访问页面测试分享效果
+
+## 注意事项
+
+### 安全域名配置
+
+- 必须在微信公众号平台配置 JS 接口安全域名
+- 域名不需要包含协议（http/https）
+- 域名不需要包含端口号
+- 支持配置多个域名
+
+### Token 缓存机制
+
+- `access_token` 有效期 7200 秒（2小时）
+- `jsapi_ticket` 有效期 7200 秒（2小时）
+- 系统自动缓存，避免频繁请求
+- 缓存提前 5 分钟过期，确保可用性
+
+### 签名算法
+
+签名字符串格式：
+```
+jsapi_ticket=TICKET&noncestr=NONCESTR&timestamp=TIMESTAMP&url=URL
+```
+
+使用 SHA1 算法生成签名。
+
+### 常见问题
+
+1. **invalid signature 错误**
+   - 检查 JS 接口安全域名配置
+   - 确认 URL 参数正确（不包含 hash 部分）
+   - 验证时间戳和签名生成逻辑
+
+2. **access_token 获取失败**
+   - 检查 AppID 和 AppSecret 配置
+   - 确认公众号类型支持相关接口
+   - 检查网络连接和防火墙设置
+
+3. **分享不生效**
+   - 确保在微信内置浏览器中测试
+   - 检查分享链接是否可访问
+   - 验证图片链接是否有效
+
+## 技术支持
+
+如果您在使用过程中遇到问题，请检查：
+
+1. 服务器日志输出
+2. 浏览器控制台错误信息
+3. 微信开发者工具调试信息
+
+## 许可证
+
+MIT License

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "wechat-ticket-server",
+  "version": "1.0.0",
+  "description": "微信公众号分享小卡片ticket获取服务",
+  "main": "wechat-ticket-server.js",
+  "scripts": {
+    "start": "node wechat-ticket-server.js",
+    "dev": "nodemon wechat-ticket-server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "axios": "^1.6.0",
+    "cors": "^2.8.5"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1"
+  },
+  "keywords": [
+    "wechat",
+    "jsapi",
+    "ticket",
+    "share"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/start-wechat-service.sh
+++ b/start-wechat-service.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# 微信公众号分享服务启动脚本
+
+echo "🚀 启动微信公众号分享服务..."
+
+# 检查 Node.js 是否安装
+if ! command -v node &> /dev/null; then
+    echo "❌ 错误: 未检测到 Node.js，请先安装 Node.js"
+    exit 1
+fi
+
+# 检查 npm 是否安装
+if ! command -v npm &> /dev/null; then
+    echo "❌ 错误: 未检测到 npm，请先安装 npm"
+    exit 1
+fi
+
+# 检查是否存在 package.json
+if [ ! -f "package.json" ]; then
+    echo "❌ 错误: 未找到 package.json 文件"
+    exit 1
+fi
+
+# 安装依赖
+echo "📦 安装依赖包..."
+npm install
+
+# 检查配置
+echo "🔧 检查配置..."
+if grep -q "YOUR_APPID" wechat-ticket-server.js; then
+    echo "⚠️  警告: 请先在 wechat-ticket-server.js 中配置您的 AppID 和 AppSecret"
+    echo "   找到以下行并替换为实际值:"
+    echo "   appId: 'YOUR_APPID'"
+    echo "   appSecret: 'YOUR_APPSECRET'"
+    echo ""
+    read -p "是否继续启动服务? (y/n): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# 启动服务
+echo "🌟 启动服务器..."
+echo "访问地址: http://localhost:3000"
+echo "测试页面: 请在浏览器中打开 wechat-share-example.html"
+echo "按 Ctrl+C 停止服务"
+echo ""
+
+npm start

--- a/wechat-share-example.html
+++ b/wechat-share-example.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>微信分享小卡片示例</title>
+    <style>
+        body {
+            font-family: 'Microsoft YaHei', Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            background: white;
+            padding: 30px;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .form-group {
+            margin-bottom: 20px;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+            color: #333;
+        }
+        input[type="text"], input[type="url"] {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            box-sizing: border-box;
+        }
+        button {
+            background-color: #1aad19;
+            color: white;
+            padding: 12px 24px;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 16px;
+            margin-right: 10px;
+        }
+        button:hover {
+            background-color: #179b16;
+        }
+        .status {
+            margin-top: 20px;
+            padding: 10px;
+            border-radius: 5px;
+        }
+        .success {
+            background-color: #d4edda;
+            color: #155724;
+            border: 1px solid #c3e6cb;
+        }
+        .error {
+            background-color: #f8d7da;
+            color: #721c24;
+            border: 1px solid #f5c6cb;
+        }
+        .info {
+            background-color: #d1ecf1;
+            color: #0c5460;
+            border: 1px solid #bee5eb;
+        }
+        .code-block {
+            background-color: #f8f9fa;
+            border: 1px solid #e9ecef;
+            border-radius: 5px;
+            padding: 15px;
+            margin: 10px 0;
+            overflow-x: auto;
+        }
+        pre {
+            margin: 0;
+            font-family: 'Courier New', monospace;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>微信公众号分享小卡片配置</h1>
+        <p>此页面用于测试微信公众号分享功能。请确保服务器已启动，并且已配置正确的AppID和AppSecret。</p>
+        
+        <div class="form-group">
+            <label for="serverUrl">服务器地址:</label>
+            <input type="url" id="serverUrl" value="http://localhost:3000" placeholder="http://localhost:3000">
+        </div>
+        
+        <div class="form-group">
+            <label for="shareTitle">分享标题:</label>
+            <input type="text" id="shareTitle" value="微信分享测试" placeholder="请输入分享标题">
+        </div>
+        
+        <div class="form-group">
+            <label for="shareDesc">分享描述:</label>
+            <input type="text" id="shareDesc" value="这是一个微信分享功能的测试页面" placeholder="请输入分享描述">
+        </div>
+        
+        <div class="form-group">
+            <label for="shareLink">分享链接:</label>
+            <input type="url" id="shareLink" value="" placeholder="请输入分享链接">
+        </div>
+        
+        <div class="form-group">
+            <label for="shareImgUrl">分享图片:</label>
+            <input type="url" id="shareImgUrl" value="" placeholder="请输入分享图片URL">
+        </div>
+        
+        <button onclick="initWechatShare()">初始化微信分享</button>
+        <button onclick="testTicket()">测试获取Ticket</button>
+        
+        <div id="status"></div>
+    </div>
+
+    <!-- 微信JS-SDK -->
+    <script src="https://res.wx.qq.com/open/js/jweixin-1.6.0.js"></script>
+    
+    <script>
+        // 设置默认的分享链接为当前页面
+        document.getElementById('shareLink').value = window.location.href;
+        
+        /**
+         * 显示状态信息
+         */
+        function showStatus(message, type = 'info') {
+            const statusDiv = document.getElementById('status');
+            statusDiv.className = `status ${type}`;
+            statusDiv.innerHTML = message;
+        }
+        
+        /**
+         * 测试获取ticket接口
+         */
+        async function testTicket() {
+            const serverUrl = document.getElementById('serverUrl').value;
+            
+            try {
+                showStatus('正在获取jsapi_ticket...', 'info');
+                
+                const response = await fetch(`${serverUrl}/api/wechat/jsapi_ticket`);
+                const result = await response.json();
+                
+                if (result.success) {
+                    showStatus(`
+                        <h3>获取ticket成功:</h3>
+                        <div class="code-block">
+                            <pre>${JSON.stringify(result.data, null, 2)}</pre>
+                        </div>
+                    `, 'success');
+                } else {
+                    showStatus(`获取ticket失败: ${result.message}`, 'error');
+                }
+            } catch (error) {
+                showStatus(`请求失败: ${error.message}`, 'error');
+            }
+        }
+        
+        /**
+         * 初始化微信分享
+         */
+        async function initWechatShare() {
+            const serverUrl = document.getElementById('serverUrl').value;
+            const shareTitle = document.getElementById('shareTitle').value;
+            const shareDesc = document.getElementById('shareDesc').value;
+            const shareLink = document.getElementById('shareLink').value;
+            const shareImgUrl = document.getElementById('shareImgUrl').value;
+            
+            if (!shareTitle || !shareDesc || !shareLink) {
+                showStatus('请填写完整的分享信息', 'error');
+                return;
+            }
+            
+            try {
+                showStatus('正在获取微信JS-SDK配置...', 'info');
+                
+                // 获取JS-SDK配置
+                const response = await fetch(`${serverUrl}/api/wechat/js_config`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        url: window.location.href.split('#')[0] // 去除hash部分
+                    })
+                });
+                
+                const result = await response.json();
+                
+                if (!result.success) {
+                    showStatus(`获取配置失败: ${result.message}`, 'error');
+                    return;
+                }
+                
+                const config = result.data;
+                
+                // 配置微信JS-SDK
+                wx.config({
+                    debug: false, // 开启调试模式
+                    appId: config.appId,
+                    timestamp: config.timestamp,
+                    nonceStr: config.nonceStr,
+                    signature: config.signature,
+                    jsApiList: config.jsApiList
+                });
+                
+                wx.ready(function () {
+                    // 配置分享到朋友圈
+                    wx.updateTimelineShareData({
+                        title: shareTitle,
+                        link: shareLink,
+                        imgUrl: shareImgUrl,
+                        success: function () {
+                            console.log('分享到朋友圈配置成功');
+                        }
+                    });
+                    
+                    // 配置分享给朋友
+                    wx.updateAppMessageShareData({
+                        title: shareTitle,
+                        desc: shareDesc,
+                        link: shareLink,
+                        imgUrl: shareImgUrl,
+                        success: function () {
+                            console.log('分享给朋友配置成功');
+                        }
+                    });
+                    
+                    showStatus(`
+                        <h3>微信分享配置成功!</h3>
+                        <p>现在您可以在微信中分享此页面，将显示自定义的标题、描述和图片。</p>
+                        <div class="code-block">
+                            <pre>配置信息:
+AppID: ${config.appId}
+时间戳: ${config.timestamp}
+随机字符串: ${config.nonceStr}
+签名: ${config.signature}</pre>
+                        </div>
+                    `, 'success');
+                });
+                
+                wx.error(function (res) {
+                    showStatus(`微信JS-SDK配置失败: ${JSON.stringify(res)}`, 'error');
+                });
+                
+            } catch (error) {
+                showStatus(`初始化失败: ${error.message}`, 'error');
+            }
+        }
+        
+        // 页面加载完成后的提示
+        window.onload = function() {
+            showStatus('请先启动后端服务器，然后点击"测试获取Ticket"按钮验证服务是否正常工作。', 'info');
+        };
+    </script>
+</body>
+</html>

--- a/wechat-ticket-server.js
+++ b/wechat-ticket-server.js
@@ -1,0 +1,204 @@
+const express = require('express');
+const axios = require('axios');
+const crypto = require('crypto');
+const cors = require('cors');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// 配置信息 - 请替换为您的实际配置
+const config = {
+    appId: 'YOUR_APPID', // 替换为您的公众号AppID
+    appSecret: 'YOUR_APPSECRET', // 替换为您的公众号AppSecret
+};
+
+// 缓存access_token和jsapi_ticket
+let tokenCache = {
+    access_token: null,
+    expires_at: 0,
+    jsapi_ticket: null,
+    ticket_expires_at: 0
+};
+
+/**
+ * 获取微信公众号access_token
+ */
+async function getAccessToken() {
+    try {
+        // 检查缓存是否有效
+        if (tokenCache.access_token && Date.now() < tokenCache.expires_at) {
+            return tokenCache.access_token;
+        }
+
+        const url = `https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid=${config.appId}&secret=${config.appSecret}`;
+        const response = await axios.get(url);
+        
+        if (response.data.errcode) {
+            throw new Error(`获取access_token失败: ${response.data.errmsg}`);
+        }
+
+        // 缓存token，提前5分钟过期
+        tokenCache.access_token = response.data.access_token;
+        tokenCache.expires_at = Date.now() + (response.data.expires_in - 300) * 1000;
+        
+        console.log('成功获取access_token');
+        return response.data.access_token;
+    } catch (error) {
+        console.error('获取access_token失败:', error.message);
+        throw error;
+    }
+}
+
+/**
+ * 获取jsapi_ticket
+ */
+async function getJsApiTicket() {
+    try {
+        // 检查缓存是否有效
+        if (tokenCache.jsapi_ticket && Date.now() < tokenCache.ticket_expires_at) {
+            return tokenCache.jsapi_ticket;
+        }
+
+        const accessToken = await getAccessToken();
+        const url = `https://api.weixin.qq.com/cgi-bin/ticket/getticket?access_token=${accessToken}&type=jsapi`;
+        const response = await axios.get(url);
+        
+        if (response.data.errcode !== 0) {
+            throw new Error(`获取jsapi_ticket失败: ${response.data.errmsg}`);
+        }
+
+        // 缓存ticket，提前5分钟过期
+        tokenCache.jsapi_ticket = response.data.ticket;
+        tokenCache.ticket_expires_at = Date.now() + (response.data.expires_in - 300) * 1000;
+        
+        console.log('成功获取jsapi_ticket');
+        return response.data.ticket;
+    } catch (error) {
+        console.error('获取jsapi_ticket失败:', error.message);
+        throw error;
+    }
+}
+
+/**
+ * 生成随机字符串
+ */
+function createNonceStr() {
+    return Math.random().toString(36).substr(2, 15);
+}
+
+/**
+ * 生成时间戳
+ */
+function createTimestamp() {
+    return parseInt(new Date().getTime() / 1000) + '';
+}
+
+/**
+ * 生成JS-SDK签名
+ */
+function createSignature(jsapi_ticket, noncestr, timestamp, url) {
+    const string = `jsapi_ticket=${jsapi_ticket}&noncestr=${noncestr}&timestamp=${timestamp}&url=${url}`;
+    return crypto.createHash('sha1').update(string).digest('hex');
+}
+
+// API路由
+
+/**
+ * 获取access_token接口
+ */
+app.get('/api/wechat/access_token', async (req, res) => {
+    try {
+        const accessToken = await getAccessToken();
+        res.json({
+            success: true,
+            data: {
+                access_token: accessToken,
+                expires_at: tokenCache.expires_at
+            }
+        });
+    } catch (error) {
+        res.status(500).json({
+            success: false,
+            message: error.message
+        });
+    }
+});
+
+/**
+ * 获取jsapi_ticket接口
+ */
+app.get('/api/wechat/jsapi_ticket', async (req, res) => {
+    try {
+        const ticket = await getJsApiTicket();
+        res.json({
+            success: true,
+            data: {
+                jsapi_ticket: ticket,
+                expires_at: tokenCache.ticket_expires_at
+            }
+        });
+    } catch (error) {
+        res.status(500).json({
+            success: false,
+            message: error.message
+        });
+    }
+});
+
+/**
+ * 获取JS-SDK配置信息接口
+ */
+app.post('/api/wechat/js_config', async (req, res) => {
+    try {
+        const { url } = req.body;
+        
+        if (!url) {
+            return res.status(400).json({
+                success: false,
+                message: '缺少url参数'
+            });
+        }
+
+        const ticket = await getJsApiTicket();
+        const noncestr = createNonceStr();
+        const timestamp = createTimestamp();
+        const signature = createSignature(ticket, noncestr, timestamp, url);
+
+        res.json({
+            success: true,
+            data: {
+                appId: config.appId,
+                timestamp: timestamp,
+                nonceStr: noncestr,
+                signature: signature,
+                jsApiList: [
+                    'updateAppMessageShareData',
+                    'updateTimelineShareData',
+                    'onMenuShareTimeline',
+                    'onMenuShareAppMessage'
+                ]
+            }
+        });
+    } catch (error) {
+        res.status(500).json({
+            success: false,
+            message: error.message
+        });
+    }
+});
+
+/**
+ * 健康检查接口
+ */
+app.get('/health', (req, res) => {
+    res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+    console.log(`微信公众号ticket服务启动成功，端口: ${PORT}`);
+    console.log(`请确保已正确配置AppID和AppSecret`);
+});
+
+module.exports = app;


### PR DESCRIPTION
Implement a Node.js service to fetch WeChat Official Account JS-SDK tickets and generate signatures for custom share cards.

This service provides RESTful APIs for `access_token`, `jsapi_ticket`, and JS-SDK configuration, including automatic caching and signature generation, along with a frontend example and detailed documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-e42f5657-3f38-438a-a7c4-9f50df3a10aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e42f5657-3f38-438a-a7c4-9f50df3a10aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

