### PR TITLE
Handle springboot i18n issues

### DIFF
--- a/java-mac-app/I18N_IMPLEMENTATION.md
+++ b/java-mac-app/I18N_IMPLEMENTATION.md
@@ -1,0 +1,196 @@
+# Java i18n Implementation Guide
+
+## Overview
+
+This document describes the internationalization (i18n) implementation for the Mac Java Application. The solution addresses the following issues that were present in the original code:
+
+### Issues Resolved
+
+1. **Hardcoded Strings**: All UI text was hardcoded in Chinese directly in the Java code
+2. **No Locale Support**: No mechanism to switch between different languages
+3. **Missing Resource Files**: No property files for different locales
+4. **Tight Coupling**: Business logic and UI text were tightly coupled
+
+## Solution Architecture
+
+### 1. I18nManager Class
+
+A singleton class that manages internationalization:
+
+- **Location**: `src/main/java/com/example/app/I18nManager.java`
+- **Features**:
+  - Singleton pattern for global access
+  - Dynamic locale switching
+  - Message parameter formatting using `MessageFormat`
+  - Locale preference persistence using Java Preferences API
+  - Fallback to English if requested locale is unavailable
+
+### 2. Resource Bundle Files
+
+Property files containing localized messages:
+
+- `src/main/resources/messages.properties` - Default (English)
+- `src/main/resources/messages_en_US.properties` - English (US)
+- `src/main/resources/messages_zh_CN.properties` - Chinese (Simplified)
+- `src/main/resources/messages_ja_JP.properties` - Japanese
+
+### 3. Application Integration
+
+The main application (`MacJavaApp.java`) was refactored to:
+
+- Use `I18nManager` for all text retrieval
+- Include a language menu for runtime locale switching
+- Dynamically update UI when locale changes
+- Separate UI components for easier text updates
+
+## Supported Languages
+
+| Locale | Language | File |
+|--------|----------|------|
+| `en` | English | `messages.properties` |
+| `en_US` | English (US) | `messages_en_US.properties` |
+| `zh_CN` | Chinese (Simplified) | `messages_zh_CN.properties` |
+| `ja_JP` | Japanese | `messages_ja_JP.properties` |
+
+## Key Features
+
+### 1. Dynamic Language Switching
+
+Users can change the application language at runtime through the "Language / 语言" menu. The change is immediate and persists across application restarts.
+
+### 2. Message Parameterization
+
+Support for parameterized messages using `MessageFormat`:
+
+```java
+// In properties file:
+file.selected=Selected file: {0}
+file.size=File size: {0} bytes
+
+// In Java code:
+i18n.getMessage("file.selected", fileName);
+i18n.getMessage("file.size", fileSize);
+```
+
+### 3. Fallback Mechanism
+
+- If a message key is not found, returns the key with markers: `!key.name!`
+- If a locale is not supported, falls back to English
+- If English is not available, uses the default resource bundle
+
+### 4. Preference Persistence
+
+User's language preference is saved using Java Preferences API and restored on application startup.
+
+## Usage Examples
+
+### Basic Message Retrieval
+
+```java
+I18nManager i18n = I18nManager.getInstance();
+String title = i18n.getMessage("app.title");
+```
+
+### Parameterized Messages
+
+```java
+String message = i18n.getMessage("system.os", System.getProperty("os.name"));
+```
+
+### Locale Management
+
+```java
+// Change locale
+i18n.setLocale(new Locale("zh", "CN"));
+
+// Get current locale
+Locale current = i18n.getCurrentLocale();
+
+// Get supported locales
+Locale[] supported = i18n.getSupportedLocales();
+```
+
+## Message Key Structure
+
+Messages are organized hierarchically:
+
+- `app.*` - Application-level messages (title, welcome, description)
+- `button.*` - Button labels
+- `status.*` - Status messages
+- `greeting.*` - Greeting dialog messages
+- `file.*` - File-related messages
+- `system.*` - System information messages
+
+## Testing
+
+A test class `I18nTest.java` is provided to verify the i18n functionality:
+
+```bash
+# Compile (without JavaFX dependencies)
+javac -cp "src/main/resources" -d . src/main/java/com/example/app/I18nManager.java src/main/java/com/example/app/I18nTest.java
+
+# Run test
+java -cp ".:src/main/resources" com.example.app.I18nTest
+```
+
+## Adding New Languages
+
+To add support for a new language:
+
+1. Create a new properties file: `messages_[language]_[COUNTRY].properties`
+2. Translate all message keys from the default `messages.properties`
+3. Add the new locale to `I18nManager.getSupportedLocales()`
+4. Test the new locale using the test class
+
+Example for French (France):
+
+```properties
+# messages_fr_FR.properties
+app.title=Application Java Mac v1.0
+app.welcome=Bienvenue dans l'application Java Mac
+# ... etc
+```
+
+```java
+// In I18nManager.getSupportedLocales()
+return new Locale[] {
+    Locale.ENGLISH,
+    new Locale("en", "US"),
+    new Locale("zh", "CN"),
+    new Locale("ja", "JP"),
+    new Locale("fr", "FR")  // Add this line
+};
+```
+
+## Best Practices
+
+1. **Consistent Key Naming**: Use hierarchical dot notation for message keys
+2. **Parameter Ordering**: Keep parameter order consistent across languages
+3. **Context Information**: Include context in key names (e.g., `button.save` vs `menu.save`)
+4. **Fallback Messages**: Always provide default English messages
+5. **Testing**: Test all supported locales before deployment
+
+## Performance Considerations
+
+- Resource bundles are cached by the JVM
+- Locale switching reloads the resource bundle but is generally fast
+- Message formatting is done on-demand, suitable for desktop applications
+- Preferences are stored locally and persist across sessions
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Missing Properties File**: Ensure all property files are in `src/main/resources`
+2. **Encoding Issues**: Use UTF-8 encoding for all property files
+3. **Missing Keys**: Check the console for `!key.name!` patterns indicating missing translations
+4. **Parameter Mismatch**: Ensure parameter counts match between locales
+
+### Debug Mode
+
+Enable debug logging by adding system property:
+```bash
+java -Djava.util.logging.level=INFO YourApp
+```
+
+This implementation provides a robust, scalable internationalization solution that can be easily extended to support additional languages and enhanced with more sophisticated features as needed.

--- a/java-mac-app/src/main/java/com/example/app/I18nManager.java
+++ b/java-mac-app/src/main/java/com/example/app/I18nManager.java
@@ -1,0 +1,153 @@
+package com.example.app;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.util.prefs.Preferences;
+
+/**
+ * Internationalization manager for handling localized messages
+ * Supports dynamic locale switching and message formatting
+ */
+public class I18nManager {
+    
+    private static final String BUNDLE_NAME = "messages";
+    private static final String LOCALE_PREF_KEY = "user.locale";
+    
+    private static I18nManager instance;
+    private ResourceBundle resourceBundle;
+    private Locale currentLocale;
+    private Preferences preferences;
+    
+    private I18nManager() {
+        preferences = Preferences.userNodeForPackage(I18nManager.class);
+        loadLocale();
+        loadResourceBundle();
+    }
+    
+    public static I18nManager getInstance() {
+        if (instance == null) {
+            instance = new I18nManager();
+        }
+        return instance;
+    }
+    
+    /**
+     * Load the saved locale from preferences or use system default
+     */
+    private void loadLocale() {
+        String savedLocale = preferences.get(LOCALE_PREF_KEY, null);
+        if (savedLocale != null) {
+            String[] parts = savedLocale.split("_");
+            if (parts.length == 2) {
+                currentLocale = new Locale(parts[0], parts[1]);
+            } else {
+                currentLocale = new Locale(parts[0]);
+            }
+        } else {
+            // Use system default locale
+            currentLocale = Locale.getDefault();
+            // If system locale is not supported, fall back to English
+            if (!isSupportedLocale(currentLocale)) {
+                currentLocale = Locale.ENGLISH;
+            }
+        }
+    }
+    
+    /**
+     * Load the resource bundle for the current locale
+     */
+    private void loadResourceBundle() {
+        try {
+            resourceBundle = ResourceBundle.getBundle(BUNDLE_NAME, currentLocale);
+        } catch (Exception e) {
+            // Fallback to default locale if current locale is not available
+            resourceBundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.ENGLISH);
+        }
+    }
+    
+    /**
+     * Get a localized message by key
+     * @param key the message key
+     * @return the localized message
+     */
+    public String getMessage(String key) {
+        try {
+            return resourceBundle.getString(key);
+        } catch (Exception e) {
+            return "!" + key + "!"; // Return key with markers if not found
+        }
+    }
+    
+    /**
+     * Get a localized message with parameters
+     * @param key the message key
+     * @param params the parameters to format into the message
+     * @return the formatted localized message
+     */
+    public String getMessage(String key, Object... params) {
+        try {
+            String message = resourceBundle.getString(key);
+            return MessageFormat.format(message, params);
+        } catch (Exception e) {
+            return "!" + key + "!"; // Return key with markers if not found
+        }
+    }
+    
+    /**
+     * Change the current locale and reload the resource bundle
+     * @param locale the new locale
+     */
+    public void setLocale(Locale locale) {
+        if (!locale.equals(currentLocale)) {
+            currentLocale = locale;
+            loadResourceBundle();
+            // Save the locale preference
+            preferences.put(LOCALE_PREF_KEY, locale.toString());
+        }
+    }
+    
+    /**
+     * Get the current locale
+     * @return the current locale
+     */
+    public Locale getCurrentLocale() {
+        return currentLocale;
+    }
+    
+    /**
+     * Get available supported locales
+     * @return array of supported locales
+     */
+    public Locale[] getSupportedLocales() {
+        return new Locale[] {
+            Locale.ENGLISH,
+            new Locale("en", "US"),
+            new Locale("zh", "CN"),
+            new Locale("ja", "JP")
+        };
+    }
+    
+    /**
+     * Check if a locale is supported
+     * @param locale the locale to check
+     * @return true if supported, false otherwise
+     */
+    public boolean isSupportedLocale(Locale locale) {
+        for (Locale supported : getSupportedLocales()) {
+            if (supported.getLanguage().equals(locale.getLanguage())) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    /**
+     * Get display name for a locale in the current locale
+     * @param locale the locale to get display name for
+     * @return the display name
+     */
+    public String getLocaleDisplayName(Locale locale) {
+        return locale.getDisplayName(currentLocale);
+    }
+}

--- a/java-mac-app/src/main/java/com/example/app/MacJavaApp.java
+++ b/java-mac-app/src/main/java/com/example/app/MacJavaApp.java
@@ -15,6 +15,7 @@ import javafx.stage.Stage;
 import java.io.File;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 /**
  * A simple JavaFX application for macOS
@@ -24,34 +25,89 @@ public class MacJavaApp extends Application {
 
     private TextArea outputArea;
     private Label statusLabel;
+    private I18nManager i18n;
+    private Label titleLabel;
+    private Label descLabel;
+    private Button helloButton;
+    private Button fileButton;
+    private Button systemInfoButton;
+    private Button clearButton;
+    private MenuBar menuBar;
 
     @Override
     public void start(Stage primaryStage) {
-        primaryStage.setTitle("Mac Java Application v1.0");
+        // Initialize i18n manager
+        i18n = I18nManager.getInstance();
+        
+        // Create menu bar
+        createMenuBar(primaryStage);
+        
+        // Set window title
+        primaryStage.setTitle(i18n.getMessage("app.title"));
 
         // Create the main layout
         VBox root = new VBox(10);
         root.setPadding(new Insets(20));
         root.setAlignment(Pos.TOP_CENTER);
 
+        // Add menu bar
+        VBox mainContainer = new VBox();
+        mainContainer.getChildren().addAll(menuBar, root);
+
+        // Initialize UI components
+        initializeComponents();
+        
+        // Add components to root
+        HBox buttonPanel = new HBox(10);
+        buttonPanel.setAlignment(Pos.CENTER);
+        buttonPanel.getChildren().addAll(helloButton, fileButton, systemInfoButton, clearButton);
+        
+        root.getChildren().addAll(titleLabel, descLabel, buttonPanel, outputArea, statusLabel);
+
+        // Create scene
+        Scene scene = new Scene(mainContainer, 600, 550);
+        primaryStage.setScene(scene);
+        primaryStage.setResizable(true);
+        primaryStage.show();
+
+        // Initial welcome message
+        appendOutput(i18n.getMessage("app.startup.success"));
+        appendOutput(i18n.getMessage("app.current.time", 
+            LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))));
+        updateStatus(i18n.getMessage("status.started"));
+    }
+    
+    private void createMenuBar(Stage primaryStage) {
+        menuBar = new MenuBar();
+        
+        // Language menu
+        Menu languageMenu = new Menu("Language / 语言");
+        
+        for (Locale locale : i18n.getSupportedLocales()) {
+            MenuItem menuItem = new MenuItem(i18n.getLocaleDisplayName(locale));
+            menuItem.setOnAction(e -> changeLanguage(locale, primaryStage));
+            languageMenu.getItems().add(menuItem);
+        }
+        
+        menuBar.getMenus().add(languageMenu);
+    }
+    
+    private void initializeComponents() {
         // Title
-        Label titleLabel = new Label("欢迎使用 Mac Java 应用程序");
+        titleLabel = new Label(i18n.getMessage("app.welcome"));
         titleLabel.setFont(Font.font("System", FontWeight.BOLD, 24));
         titleLabel.setTextFill(Color.DARKBLUE);
 
         // Description
-        Label descLabel = new Label("这是一个为macOS设计的Java应用程序示例");
+        descLabel = new Label(i18n.getMessage("app.description"));
         descLabel.setFont(Font.font("System", 14));
         descLabel.setTextFill(Color.GRAY);
 
-        // Button panel
-        HBox buttonPanel = new HBox(10);
-        buttonPanel.setAlignment(Pos.CENTER);
-
-        Button helloButton = new Button("问候消息");
-        Button fileButton = new Button("选择文件");
-        Button systemInfoButton = new Button("系统信息");
-        Button clearButton = new Button("清空输出");
+        // Buttons
+        helloButton = new Button(i18n.getMessage("button.greeting"));
+        fileButton = new Button(i18n.getMessage("button.selectFile"));
+        systemInfoButton = new Button(i18n.getMessage("button.systemInfo"));
+        clearButton = new Button(i18n.getMessage("button.clear"));
 
         // Style buttons
         String buttonStyle = "-fx-background-color: #007AFF; -fx-text-fill: white; -fx-font-size: 14px; -fx-padding: 10 20 10 20; -fx-background-radius: 5;";
@@ -59,8 +115,6 @@ public class MacJavaApp extends Application {
         fileButton.setStyle(buttonStyle);
         systemInfoButton.setStyle(buttonStyle);
         clearButton.setStyle("-fx-background-color: #FF3B30; -fx-text-fill: white; -fx-font-size: 14px; -fx-padding: 10 20 10 20; -fx-background-radius: 5;");
-
-        buttonPanel.getChildren().addAll(helloButton, fileButton, systemInfoButton, clearButton);
 
         // Output area
         outputArea = new TextArea();
@@ -70,80 +124,94 @@ public class MacJavaApp extends Application {
         outputArea.setStyle("-fx-font-family: 'Monaco', 'Consolas', monospace; -fx-font-size: 12px;");
 
         // Status bar
-        statusLabel = new Label("就绪");
+        statusLabel = new Label(i18n.getMessage("status.ready"));
         statusLabel.setStyle("-fx-background-color: #F0F0F0; -fx-padding: 5; -fx-font-size: 12px;");
 
         // Event handlers
         helloButton.setOnAction(e -> showGreeting());
-        fileButton.setOnAction(e -> selectFile(primaryStage));
+        fileButton.setOnAction(e -> selectFile((Stage) helloButton.getScene().getWindow()));
         systemInfoButton.setOnAction(e -> showSystemInfo());
         clearButton.setOnAction(e -> clearOutput());
-
-        // Add components to root
-        root.getChildren().addAll(titleLabel, descLabel, buttonPanel, outputArea, statusLabel);
-
-        // Create scene
-        Scene scene = new Scene(root, 600, 500);
-        primaryStage.setScene(scene);
-        primaryStage.setResizable(true);
-        primaryStage.show();
-
-        // Initial welcome message
-        appendOutput("应用程序启动成功！");
-        appendOutput("当前时间: " + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
-        updateStatus("应用程序已启动");
+    }
+    
+    private void changeLanguage(Locale locale, Stage primaryStage) {
+        i18n.setLocale(locale);
+        refreshUI(primaryStage);
+    }
+    
+    private void refreshUI(Stage primaryStage) {
+        // Update window title
+        primaryStage.setTitle(i18n.getMessage("app.title"));
+        
+        // Update all text components
+        titleLabel.setText(i18n.getMessage("app.welcome"));
+        descLabel.setText(i18n.getMessage("app.description"));
+        helloButton.setText(i18n.getMessage("button.greeting"));
+        fileButton.setText(i18n.getMessage("button.selectFile"));
+        systemInfoButton.setText(i18n.getMessage("button.systemInfo"));
+        clearButton.setText(i18n.getMessage("button.clear"));
+        
+        // Update status if it shows ready
+        if (statusLabel.getText().contains("Ready") || statusLabel.getText().contains("就绪")) {
+            statusLabel.setText(i18n.getMessage("status.ready"));
+        }
+        
+        appendOutput("Language changed to: " + i18n.getCurrentLocale().getDisplayName());
     }
 
     private void showGreeting() {
-        String greeting = "你好！欢迎使用这个Java应用程序！\n" +
-                         "这个程序演示了:\n" +
-                         "• JavaFX GUI界面\n" +
-                         "• 文件选择功能\n" +
-                         "• 系统信息显示\n" +
-                         "• macOS集成";
-        appendOutput(greeting);
-        updateStatus("显示问候消息");
+        StringBuilder greeting = new StringBuilder();
+        greeting.append(i18n.getMessage("greeting.hello")).append("\n");
+        greeting.append(i18n.getMessage("greeting.features")).append("\n");
+        greeting.append(i18n.getMessage("greeting.feature1")).append("\n");
+        greeting.append(i18n.getMessage("greeting.feature2")).append("\n");
+        greeting.append(i18n.getMessage("greeting.feature3")).append("\n");
+        greeting.append(i18n.getMessage("greeting.feature4"));
+        
+        appendOutput(greeting.toString());
+        updateStatus(i18n.getMessage("status.greeting"));
     }
 
     private void selectFile(Stage stage) {
         FileChooser fileChooser = new FileChooser();
-        fileChooser.setTitle("选择文件");
+        fileChooser.setTitle(i18n.getMessage("file.chooser.title"));
         fileChooser.getExtensionFilters().addAll(
-                new FileChooser.ExtensionFilter("所有文件", "*.*"),
-                new FileChooser.ExtensionFilter("文本文件", "*.txt"),
-                new FileChooser.ExtensionFilter("图片文件", "*.png", "*.jpg", "*.gif")
+                new FileChooser.ExtensionFilter(i18n.getMessage("file.chooser.allFiles"), "*.*"),
+                new FileChooser.ExtensionFilter(i18n.getMessage("file.chooser.textFiles"), "*.txt"),
+                new FileChooser.ExtensionFilter(i18n.getMessage("file.chooser.imageFiles"), "*.png", "*.jpg", "*.gif")
         );
 
         File selectedFile = fileChooser.showOpenDialog(stage);
         if (selectedFile != null) {
-            appendOutput("选择的文件: " + selectedFile.getAbsolutePath());
-            appendOutput("文件大小: " + selectedFile.length() + " 字节");
-            appendOutput("文件可读: " + (selectedFile.canRead() ? "是" : "否"));
-            updateStatus("文件已选择: " + selectedFile.getName());
+            appendOutput(i18n.getMessage("file.selected", selectedFile.getAbsolutePath()));
+            appendOutput(i18n.getMessage("file.size", selectedFile.length()));
+            String readableText = selectedFile.canRead() ? i18n.getMessage("file.yes") : i18n.getMessage("file.no");
+            appendOutput(i18n.getMessage("file.readable", readableText));
+            updateStatus(i18n.getMessage("status.fileSelected", selectedFile.getName()));
         } else {
-            updateStatus("文件选择已取消");
+            updateStatus(i18n.getMessage("status.fileCancelled"));
         }
     }
 
     private void showSystemInfo() {
-        appendOutput("=== 系统信息 ===");
-        appendOutput("操作系统: " + System.getProperty("os.name"));
-        appendOutput("系统版本: " + System.getProperty("os.version"));
-        appendOutput("系统架构: " + System.getProperty("os.arch"));
-        appendOutput("Java版本: " + System.getProperty("java.version"));
-        appendOutput("Java供应商: " + System.getProperty("java.vendor"));
-        appendOutput("用户名: " + System.getProperty("user.name"));
-        appendOutput("用户主目录: " + System.getProperty("user.home"));
-        appendOutput("工作目录: " + System.getProperty("user.dir"));
-        appendOutput("可用处理器: " + Runtime.getRuntime().availableProcessors());
-        appendOutput("最大内存: " + Runtime.getRuntime().maxMemory() / 1024 / 1024 + " MB");
-        appendOutput("已用内存: " + (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1024 / 1024 + " MB");
-        updateStatus("系统信息已显示");
+        appendOutput("=== " + i18n.getMessage("system.info.title") + " ===");
+        appendOutput(i18n.getMessage("system.os", System.getProperty("os.name")));
+        appendOutput(i18n.getMessage("system.version", System.getProperty("os.version")));
+        appendOutput(i18n.getMessage("system.arch", System.getProperty("os.arch")));
+        appendOutput(i18n.getMessage("system.java.version", System.getProperty("java.version")));
+        appendOutput(i18n.getMessage("system.java.vendor", System.getProperty("java.vendor")));
+        appendOutput(i18n.getMessage("system.user.name", System.getProperty("user.name")));
+        appendOutput(i18n.getMessage("system.user.home", System.getProperty("user.home")));
+        appendOutput(i18n.getMessage("system.user.dir", System.getProperty("user.dir")));
+        appendOutput(i18n.getMessage("system.processors", Runtime.getRuntime().availableProcessors()));
+        appendOutput(i18n.getMessage("system.memory.max", Runtime.getRuntime().maxMemory() / 1024 / 1024));
+        appendOutput(i18n.getMessage("system.memory.used", (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1024 / 1024));
+        updateStatus(i18n.getMessage("status.systemInfo"));
     }
 
     private void clearOutput() {
         outputArea.clear();
-        updateStatus("输出已清空");
+        updateStatus(i18n.getMessage("status.outputCleared"));
     }
 
     private void appendOutput(String text) {
@@ -152,7 +220,7 @@ public class MacJavaApp extends Application {
     }
 
     private void updateStatus(String status) {
-        statusLabel.setText("状态: " + status);
+        statusLabel.setText(status);
     }
 
     public static void main(String[] args) {

--- a/java-mac-app/src/main/resources/messages.properties
+++ b/java-mac-app/src/main/resources/messages.properties
@@ -1,0 +1,56 @@
+# Default messages (English)
+app.title=Mac Java Application v1.0
+app.welcome=Welcome to Mac Java Application
+app.description=This is a Java application example designed for macOS
+
+# Buttons
+button.greeting=Greeting Message
+button.selectFile=Select File
+button.systemInfo=System Info
+button.clear=Clear Output
+
+# Status messages
+status.ready=Ready
+status.started=Application started
+status.greeting=Greeting message displayed
+status.fileSelected=File selected: {0}
+status.fileCancelled=File selection cancelled
+status.systemInfo=System information displayed
+status.outputCleared=Output cleared
+
+# Greeting message
+greeting.hello=Hello! Welcome to this Java application!
+greeting.features=This program demonstrates:
+greeting.feature1=• JavaFX GUI interface
+greeting.feature2=• File selection functionality
+greeting.feature3=• System information display
+greeting.feature4=• macOS integration
+
+# File chooser
+file.chooser.title=Select File
+file.chooser.allFiles=All Files
+file.chooser.textFiles=Text Files
+file.chooser.imageFiles=Image Files
+file.selected=Selected file: {0}
+file.size=File size: {0} bytes
+file.readable=File readable: {0}
+file.yes=Yes
+file.no=No
+
+# System info
+system.info.title=System Information
+system.os=Operating System: {0}
+system.version=System Version: {0}
+system.arch=System Architecture: {0}
+system.java.version=Java Version: {0}
+system.java.vendor=Java Vendor: {0}
+system.user.name=Username: {0}
+system.user.home=User Home: {0}
+system.user.dir=Working Directory: {0}
+system.processors=Available Processors: {0}
+system.memory.max=Maximum Memory: {0} MB
+system.memory.used=Used Memory: {0} MB
+
+# Application messages
+app.startup.success=Application started successfully!
+app.current.time=Current time: {0}

--- a/java-mac-app/src/main/resources/messages_en_US.properties
+++ b/java-mac-app/src/main/resources/messages_en_US.properties
@@ -1,0 +1,56 @@
+# English (US) messages
+app.title=Mac Java Application v1.0
+app.welcome=Welcome to Mac Java Application
+app.description=This is a Java application example designed for macOS
+
+# Buttons
+button.greeting=Greeting Message
+button.selectFile=Select File
+button.systemInfo=System Info
+button.clear=Clear Output
+
+# Status messages
+status.ready=Ready
+status.started=Application started
+status.greeting=Greeting message displayed
+status.fileSelected=File selected: {0}
+status.fileCancelled=File selection cancelled
+status.systemInfo=System information displayed
+status.outputCleared=Output cleared
+
+# Greeting message
+greeting.hello=Hello! Welcome to this Java application!
+greeting.features=This program demonstrates:
+greeting.feature1=• JavaFX GUI interface
+greeting.feature2=• File selection functionality
+greeting.feature3=• System information display
+greeting.feature4=• macOS integration
+
+# File chooser
+file.chooser.title=Select File
+file.chooser.allFiles=All Files
+file.chooser.textFiles=Text Files
+file.chooser.imageFiles=Image Files
+file.selected=Selected file: {0}
+file.size=File size: {0} bytes
+file.readable=File readable: {0}
+file.yes=Yes
+file.no=No
+
+# System info
+system.info.title=System Information
+system.os=Operating System: {0}
+system.version=System Version: {0}
+system.arch=System Architecture: {0}
+system.java.version=Java Version: {0}
+system.java.vendor=Java Vendor: {0}
+system.user.name=Username: {0}
+system.user.home=User Home: {0}
+system.user.dir=Working Directory: {0}
+system.processors=Available Processors: {0}
+system.memory.max=Maximum Memory: {0} MB
+system.memory.used=Used Memory: {0} MB
+
+# Application messages
+app.startup.success=Application started successfully!
+app.current.time=Current time: {0}

--- a/java-mac-app/src/main/resources/messages_ja_JP.properties
+++ b/java-mac-app/src/main/resources/messages_ja_JP.properties
@@ -1,0 +1,56 @@
+# Japanese messages
+app.title=Mac Java アプリケーション v1.0
+app.welcome=Mac Java アプリケーションへようこそ
+app.description=これはmacOS用に設計されたJavaアプリケーションの例です
+
+# Buttons
+button.greeting=挨拶メッセージ
+button.selectFile=ファイル選択
+button.systemInfo=システム情報
+button.clear=出力をクリア
+
+# Status messages
+status.ready=準備完了
+status.started=アプリケーションが開始されました
+status.greeting=挨拶メッセージを表示しました
+status.fileSelected=ファイルが選択されました: {0}
+status.fileCancelled=ファイル選択がキャンセルされました
+status.systemInfo=システム情報を表示しました
+status.outputCleared=出力がクリアされました
+
+# Greeting message
+greeting.hello=こんにちは！このJavaアプリケーションへようこそ！
+greeting.features=このプログラムは以下を実演します:
+greeting.feature1=• JavaFX GUIインターフェース
+greeting.feature2=• ファイル選択機能
+greeting.feature3=• システム情報表示
+greeting.feature4=• macOS統合
+
+# File chooser
+file.chooser.title=ファイルを選択
+file.chooser.allFiles=すべてのファイル
+file.chooser.textFiles=テキストファイル
+file.chooser.imageFiles=画像ファイル
+file.selected=選択されたファイル: {0}
+file.size=ファイルサイズ: {0} バイト
+file.readable=ファイル読み取り可能: {0}
+file.yes=はい
+file.no=いいえ
+
+# System info
+system.info.title=システム情報
+system.os=オペレーティングシステム: {0}
+system.version=システムバージョン: {0}
+system.arch=システムアーキテクチャ: {0}
+system.java.version=Javaバージョン: {0}
+system.java.vendor=Javaベンダー: {0}
+system.user.name=ユーザー名: {0}
+system.user.home=ユーザーホーム: {0}
+system.user.dir=作業ディレクトリ: {0}
+system.processors=利用可能プロセッサ: {0}
+system.memory.max=最大メモリ: {0} MB
+system.memory.used=使用メモリ: {0} MB
+
+# Application messages
+app.startup.success=アプリケーションが正常に開始されました！
+app.current.time=現在時刻: {0}

--- a/java-mac-app/src/main/resources/messages_zh_CN.properties
+++ b/java-mac-app/src/main/resources/messages_zh_CN.properties
@@ -1,0 +1,56 @@
+# Chinese (Simplified) messages
+app.title=Mac Java 应用程序 v1.0
+app.welcome=欢迎使用 Mac Java 应用程序
+app.description=这是一个为macOS设计的Java应用程序示例
+
+# Buttons
+button.greeting=问候消息
+button.selectFile=选择文件
+button.systemInfo=系统信息
+button.clear=清空输出
+
+# Status messages
+status.ready=就绪
+status.started=应用程序已启动
+status.greeting=显示问候消息
+status.fileSelected=文件已选择: {0}
+status.fileCancelled=文件选择已取消
+status.systemInfo=系统信息已显示
+status.outputCleared=输出已清空
+
+# Greeting message
+greeting.hello=你好！欢迎使用这个Java应用程序！
+greeting.features=这个程序演示了:
+greeting.feature1=• JavaFX GUI界面
+greeting.feature2=• 文件选择功能
+greeting.feature3=• 系统信息显示
+greeting.feature4=• macOS集成
+
+# File chooser
+file.chooser.title=选择文件
+file.chooser.allFiles=所有文件
+file.chooser.textFiles=文本文件
+file.chooser.imageFiles=图片文件
+file.selected=选择的文件: {0}
+file.size=文件大小: {0} 字节
+file.readable=文件可读: {0}
+file.yes=是
+file.no=否
+
+# System info
+system.info.title=系统信息
+system.os=操作系统: {0}
+system.version=系统版本: {0}
+system.arch=系统架构: {0}
+system.java.version=Java版本: {0}
+system.java.vendor=Java供应商: {0}
+system.user.name=用户名: {0}
+system.user.home=用户主目录: {0}
+system.user.dir=工作目录: {0}
+system.processors=可用处理器: {0}
+system.memory.max=最大内存: {0} MB
+system.memory.used=已用内存: {0} MB
+
+# Application messages
+app.startup.success=应用程序启动成功！
+app.current.time=当前时间: {0}


### PR DESCRIPTION
Implement internationalization (i18n) support to enable dynamic language switching and remove hardcoded text in the JavaFX application.

This PR addresses the complete lack of i18n in the original codebase by introducing a dedicated `I18nManager`, resource bundles for multiple languages (English, Simplified Chinese, Japanese), and refactoring the UI to dynamically load localized messages. It also adds a language selection menu and persists user language preferences.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d545d3c-c677-4d8f-a4d3-cdb35f26b34e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d545d3c-c677-4d8f-a4d3-cdb35f26b34e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

