### PR TITLE
Enterprise notification subscription center

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,8 @@
 {
   "pages": [
     "pages/game/game",
-    "pages/watermark/watermark"
+    "pages/watermark/watermark",
+    "pages/subscriptionCenter/subscriptionCenter"
   ],
   "window": {
     "backgroundTextStyle": "light",

--- a/pages/subscriptionCenter/subscriptionCenter.js
+++ b/pages/subscriptionCenter/subscriptionCenter.js
@@ -1,0 +1,148 @@
+// pages/subscriptionCenter/subscriptionCenter.js
+const SubscriptionCenter = require('../../utils/subscriptionCenter.js');
+
+function formatDateTime(ts) {
+  if (!ts) return '';
+  const d = new Date(ts);
+  const pad = (n) => (n < 10 ? `0${n}` : `${n}`);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+Page({
+  data: {
+    items: [],
+    requesting: false,
+    lastSavedAt: '',
+    statusText: {
+      accept: '已同意',
+      reject: '已拒绝',
+      ban: '被限制/关闭',
+      '': ''
+    }
+  },
+
+  onLoad() {
+    this.refreshFromStorage();
+  },
+
+  onShow() {
+    // 防止其它页面改动状态后，这里不刷新
+    this.refreshFromStorage();
+  },
+
+  refreshFromStorage() {
+    const defaults = SubscriptionCenter.getDefaultTemplates();
+    const state = SubscriptionCenter.loadState();
+    const merged = SubscriptionCenter.mergeTemplates(defaults, state || {});
+    this.setData({
+      items: merged,
+      lastSavedAt: state && state.lastSavedAt ? formatDateTime(state.lastSavedAt) : ''
+    });
+  },
+
+  persist(items) {
+    const next = {
+      version: 1,
+      items,
+      lastSavedAt: Date.now()
+    };
+    SubscriptionCenter.saveState(next);
+    this.setData({
+      lastSavedAt: formatDateTime(next.lastSavedAt)
+    });
+  },
+
+  onToggle(e) {
+    const key = e.currentTarget.dataset.key;
+    const enabled = !!(e.detail && e.detail.value);
+
+    const items = (this.data.items || []).map((it) => {
+      if (it.key !== key) return it;
+      return { ...it, enabled };
+    });
+
+    this.setData({ items });
+    this.persist(items);
+  },
+
+  selectAll() {
+    const items = (this.data.items || []).map((it) => ({ ...it, enabled: true }));
+    this.setData({ items });
+    this.persist(items);
+  },
+
+  clearAll() {
+    const items = (this.data.items || []).map((it) => ({ ...it, enabled: false }));
+    this.setData({ items });
+    this.persist(items);
+  },
+
+  resetState() {
+    const defaults = SubscriptionCenter.getDefaultTemplates();
+    const items = defaults.map((it) => ({ ...it }));
+    this.setData({ items, lastSavedAt: '' });
+    SubscriptionCenter.saveState({
+      version: 1,
+      items,
+      lastSavedAt: Date.now()
+    });
+    wx.showToast({ title: '已清空', icon: 'success' });
+  },
+
+  requestSubscribe() {
+    if (this.data.requesting) return;
+
+    const selected = (this.data.items || []).filter((it) => it.enabled);
+    const tmplIds = selected
+      .map((it) => it.tmplId)
+      .filter((id) => typeof id === 'string' && id.trim().length > 0);
+
+    if (tmplIds.length === 0) {
+      wx.showToast({ title: '请先选择通知类型', icon: 'none' });
+      return;
+    }
+
+    // 避免占位符误请求
+    const hasPlaceholder = tmplIds.some((id) => id.startsWith('TEMPLATE_ID_'));
+    if (hasPlaceholder) {
+      wx.showModal({
+        title: '需要配置模板ID',
+        content: '当前使用的是占位模板ID（TEMPLATE_ID_xxx）。请先替换为你的小程序订阅消息真实模板ID，再发起订阅。',
+        showCancel: false
+      });
+      return;
+    }
+
+    this.setData({ requesting: true });
+
+    wx.requestSubscribeMessage({
+      tmplIds,
+      success: (res) => {
+        const now = Date.now();
+        const items = (this.data.items || []).map((it) => {
+          if (!it.enabled) return it;
+          const status = res && it.tmplId ? res[it.tmplId] : '';
+          if (!status) return it;
+          return {
+            ...it,
+            lastStatus: status,
+            lastRequestedAt: formatDateTime(now)
+          };
+        });
+
+        this.setData({ items });
+        this.persist(items);
+
+        wx.showToast({ title: '已提交订阅请求', icon: 'success' });
+      },
+      fail: (err) => {
+        console.error('requestSubscribeMessage failed', err);
+        wx.showToast({ title: '订阅失败', icon: 'none' });
+      },
+      complete: () => {
+        this.setData({ requesting: false });
+      }
+    });
+  }
+});
+

--- a/pages/subscriptionCenter/subscriptionCenter.json
+++ b/pages/subscriptionCenter/subscriptionCenter.json
@@ -1,0 +1,9 @@
+{
+  "usingComponents": {},
+  "navigationBarTitleText": "企业通知订阅中心",
+  "navigationBarBackgroundColor": "#1f2937",
+  "navigationBarTextStyle": "white",
+  "backgroundColor": "#0b1220",
+  "enablePullDownRefresh": false
+}
+

--- a/pages/subscriptionCenter/subscriptionCenter.wxml
+++ b/pages/subscriptionCenter/subscriptionCenter.wxml
@@ -1,0 +1,64 @@
+<!-- pages/subscriptionCenter/subscriptionCenter.wxml -->
+<view class="page">
+  <view class="header">
+    <text class="title">企业通知订阅中心</text>
+    <text class="subtitle">选择你希望接收的订阅通知类型</text>
+  </view>
+
+  <view class="card tips">
+    <text class="tips-title">说明</text>
+    <text class="tips-text">
+      订阅消息通常为“单次订阅”，需要在关键操作时再次发起订阅申请。本页面用于统一管理你偏好的通知类型，并在你点击按钮时批量发起订阅请求。
+    </text>
+  </view>
+
+  <view class="card">
+    <view class="card-header">
+      <text class="card-title">通知类型</text>
+      <view class="quick-actions">
+        <button class="ghost-btn" size="mini" bindtap="selectAll">全选</button>
+        <button class="ghost-btn" size="mini" bindtap="clearAll">全不选</button>
+      </view>
+    </view>
+
+    <view class="list">
+      <view
+        class="row"
+        wx:for="{{items}}"
+        wx:key="key"
+      >
+        <view class="row-left">
+          <text class="row-title">{{item.title}}</text>
+          <text class="row-desc">{{item.desc}}</text>
+          <view class="row-meta" wx:if="{{item.lastStatus}}">
+            <text class="meta-pill {{item.lastStatus === 'accept' ? 'ok' : (item.lastStatus === 'reject' ? 'bad' : 'muted')}}">
+              {{statusText[item.lastStatus] || item.lastStatus}}
+            </text>
+            <text class="meta-time" wx:if="{{item.lastRequestedAt}}">· {{item.lastRequestedAt}}</text>
+          </view>
+        </view>
+        <view class="row-right">
+          <switch
+            checked="{{item.enabled}}"
+            bindchange="onToggle"
+            data-key="{{item.key}}"
+          />
+        </view>
+      </view>
+    </view>
+  </view>
+
+  <view class="card">
+    <text class="card-title">操作</text>
+    <view class="actions">
+      <button class="primary-btn" bindtap="requestSubscribe" disabled="{{requesting}}">
+        {{requesting ? '请求中...' : '订阅选中通知'}}
+      </button>
+      <button class="danger-btn" bindtap="resetState" disabled="{{requesting}}">
+        清空本地记录
+      </button>
+    </view>
+    <text class="footnote" wx:if="{{lastSavedAt}}">本地记录更新时间：{{lastSavedAt}}</text>
+  </view>
+</view>
+

--- a/pages/subscriptionCenter/subscriptionCenter.wxss
+++ b/pages/subscriptionCenter/subscriptionCenter.wxss
@@ -1,0 +1,204 @@
+/* pages/subscriptionCenter/subscriptionCenter.wxss */
+.page {
+  min-height: 100vh;
+  padding: 24rpx;
+  background: radial-gradient(1200rpx 600rpx at 20% 0%, rgba(99, 102, 241, 0.35), transparent 60%),
+    radial-gradient(900rpx 500rpx at 90% 10%, rgba(34, 197, 94, 0.18), transparent 55%),
+    linear-gradient(180deg, #0b1220 0%, #070b14 100%);
+  box-sizing: border-box;
+}
+
+.header {
+  padding: 28rpx 22rpx;
+  margin-bottom: 18rpx;
+}
+
+.title {
+  display: block;
+  color: #ffffff;
+  font-size: 40rpx;
+  font-weight: 800;
+  letter-spacing: 1rpx;
+}
+
+.subtitle {
+  display: block;
+  margin-top: 10rpx;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 26rpx;
+}
+
+.card {
+  background: rgba(17, 24, 39, 0.75);
+  border: 1rpx solid rgba(255, 255, 255, 0.06);
+  border-radius: 20rpx;
+  padding: 22rpx;
+  margin-bottom: 18rpx;
+  box-shadow: 0 10rpx 30rpx rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(10px);
+}
+
+.tips-title {
+  display: block;
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 700;
+  font-size: 28rpx;
+  margin-bottom: 10rpx;
+}
+
+.tips-text {
+  display: block;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 24rpx;
+  line-height: 36rpx;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12rpx;
+}
+
+.card-title {
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 30rpx;
+  font-weight: 700;
+}
+
+.quick-actions {
+  display: flex;
+  gap: 14rpx;
+}
+
+.ghost-btn {
+  background: rgba(255, 255, 255, 0.06) !important;
+  color: rgba(255, 255, 255, 0.86) !important;
+  border: 1rpx solid rgba(255, 255, 255, 0.12) !important;
+  border-radius: 999rpx !important;
+  padding: 0 18rpx !important;
+}
+
+.list {
+  margin-top: 8rpx;
+}
+
+.row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 18rpx 8rpx;
+  border-top: 1rpx solid rgba(255, 255, 255, 0.06);
+}
+
+.row:first-child {
+  border-top: none;
+}
+
+.row-left {
+  flex: 1;
+  padding-right: 18rpx;
+}
+
+.row-title {
+  display: block;
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 28rpx;
+  font-weight: 700;
+}
+
+.row-desc {
+  display: block;
+  margin-top: 8rpx;
+  color: rgba(255, 255, 255, 0.68);
+  font-size: 24rpx;
+  line-height: 34rpx;
+}
+
+.row-meta {
+  display: flex;
+  align-items: center;
+  margin-top: 10rpx;
+  gap: 10rpx;
+}
+
+.meta-pill {
+  font-size: 22rpx;
+  padding: 6rpx 12rpx;
+  border-radius: 999rpx;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.78);
+  border: 1rpx solid rgba(255, 255, 255, 0.10);
+}
+
+.meta-pill.ok {
+  background: rgba(34, 197, 94, 0.16);
+  border-color: rgba(34, 197, 94, 0.35);
+  color: rgba(166, 255, 200, 0.95);
+}
+
+.meta-pill.bad {
+  background: rgba(239, 68, 68, 0.16);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: rgba(255, 200, 200, 0.95);
+}
+
+.meta-pill.muted {
+  opacity: 0.85;
+}
+
+.meta-time {
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 22rpx;
+}
+
+.row-right {
+  display: flex;
+  align-items: center;
+}
+
+.actions {
+  margin-top: 14rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 14rpx;
+}
+
+.primary-btn {
+  width: 100%;
+  border: none;
+  border-radius: 16rpx;
+  padding: 22rpx 18rpx;
+  color: #ffffff;
+  font-size: 30rpx;
+  font-weight: 800;
+  background: linear-gradient(135deg, #6366f1 0%, #22c55e 120%);
+  box-shadow: 0 14rpx 30rpx rgba(99, 102, 241, 0.22);
+}
+
+.primary-btn[disabled] {
+  opacity: 0.55;
+}
+
+.danger-btn {
+  width: 100%;
+  border: 1rpx solid rgba(239, 68, 68, 0.35);
+  border-radius: 16rpx;
+  padding: 18rpx 18rpx;
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 28rpx;
+  font-weight: 700;
+  background: rgba(239, 68, 68, 0.12);
+}
+
+.danger-btn[disabled] {
+  opacity: 0.55;
+}
+
+.footnote {
+  display: block;
+  margin-top: 14rpx;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 22rpx;
+}
+

--- a/utils/subscriptionCenter.js
+++ b/utils/subscriptionCenter.js
@@ -1,0 +1,95 @@
+// utils/subscriptionCenter.js
+// 企业通知订阅中心：模板配置 + 本地状态持久化
+
+const STORAGE_KEY = 'enterprise_notification_subscription_center_v1';
+
+function getDefaultTemplates() {
+  // 注意：tmplId 需要替换为你的小程序「订阅消息」真实模板ID
+  return [
+    {
+      key: 'approval_result',
+      title: '审批结果通知',
+      desc: '审批通过/驳回/转交等结果提醒',
+      tmplId: 'TEMPLATE_ID_APPROVAL_RESULT',
+      enabled: true
+    },
+    {
+      key: 'ticket_status',
+      title: '工单状态通知',
+      desc: '工单创建、处理中、已完成等状态变更提醒',
+      tmplId: 'TEMPLATE_ID_TICKET_STATUS',
+      enabled: true
+    },
+    {
+      key: 'security_alert',
+      title: '安全告警通知',
+      desc: '账号异常、风控触发、关键操作等提醒',
+      tmplId: 'TEMPLATE_ID_SECURITY_ALERT',
+      enabled: false
+    },
+    {
+      key: 'system_announcement',
+      title: '系统公告通知',
+      desc: '版本更新、维护窗口、重要公告提醒',
+      tmplId: 'TEMPLATE_ID_SYSTEM_ANNOUNCEMENT',
+      enabled: false
+    }
+  ];
+}
+
+function safeGetStorageSync(key) {
+  try {
+    return wx.getStorageSync(key);
+  } catch (e) {
+    return null;
+  }
+}
+
+function safeSetStorageSync(key, value) {
+  try {
+    wx.setStorageSync(key, value);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function loadState() {
+  const state = safeGetStorageSync(STORAGE_KEY);
+  if (!state || typeof state !== 'object') return null;
+  return state;
+}
+
+function saveState(state) {
+  return safeSetStorageSync(STORAGE_KEY, state);
+}
+
+function mergeTemplates(defaultTemplates, state) {
+  const byKey = {};
+  (defaultTemplates || []).forEach((t) => {
+    byKey[t.key] = { ...t };
+  });
+
+  const savedItems = state && Array.isArray(state.items) ? state.items : [];
+  savedItems.forEach((saved) => {
+    if (!saved || !saved.key) return;
+    if (!byKey[saved.key]) return;
+    byKey[saved.key] = {
+      ...byKey[saved.key],
+      enabled: typeof saved.enabled === 'boolean' ? saved.enabled : byKey[saved.key].enabled,
+      lastStatus: saved.lastStatus || byKey[saved.key].lastStatus,
+      lastRequestedAt: saved.lastRequestedAt || byKey[saved.key].lastRequestedAt
+    };
+  });
+
+  return Object.keys(byKey).map((k) => byKey[k]);
+}
+
+module.exports = {
+  STORAGE_KEY,
+  getDefaultTemplates,
+  loadState,
+  saveState,
+  mergeTemplates
+};
+


### PR DESCRIPTION
Add an "Enterprise Notification Subscription Center" page to allow users to manage and subscribe to various enterprise notifications.

The page provides a centralized interface for users to select preferred notification types, persist their choices locally, and initiate subscription requests for multiple templates at once. It includes placeholder template IDs that need to be replaced with actual WeChat Mini Program subscription message template IDs.

---
<a href="https://cursor.com/background-agent?bcId=bc-a39cf941-2f37-4f36-81a3-511f9703574e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a39cf941-2f37-4f36-81a3-511f9703574e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

