### PR TITLE
A标签内容提取

### DIFF
--- a/java-mac-app/README.md
+++ b/java-mac-app/README.md
@@ -143,6 +143,17 @@ java-mac-app/
 2. 如需要新的依赖，在 `pom.xml` 中添加
 3. 更新 `module-info.java` 如果使用了新的模块
 
+### 去除 a 标签示例（保留标签内容）
+
+项目中新增了 `HtmlAnchorCleaner` 工具类：
+
+```java
+String html = "欢迎访问 <a href=\"https://example.com\">官网</a>，查看<a target=\"_blank\" href=\"/help\">帮助中心</a>";
+String cleaned = HtmlAnchorCleaner.removeAnchorTags(html);
+System.out.println(cleaned);
+// 输出: 欢迎访问 官网，查看帮助中心
+```
+
 ## 故障排除
 
 ### 常见问题

--- a/java-mac-app/src/main/java/com/example/app/HtmlAnchorCleaner.java
+++ b/java-mac-app/src/main/java/com/example/app/HtmlAnchorCleaner.java
@@ -1,0 +1,22 @@
+package com.example.app;
+
+import java.util.regex.Pattern;
+
+/**
+ * HTML anchor tag cleaner.
+ * Removes only opening/closing a-tags while keeping their inner content.
+ */
+public final class HtmlAnchorCleaner {
+    private static final Pattern A_TAG_PATTERN = Pattern.compile("(?i)</?a\\b[^>]*>");
+
+    private HtmlAnchorCleaner() {
+        // Utility class
+    }
+
+    public static String removeAnchorTags(String html) {
+        if (html == null || html.isEmpty()) {
+            return html;
+        }
+        return A_TAG_PATTERN.matcher(html).replaceAll("");
+    }
+}


### PR DESCRIPTION
Add `HtmlAnchorCleaner` utility to remove `<a>` tags while preserving their content.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b121d626-a276-4fe7-8fbe-28d457fc388b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b121d626-a276-4fe7-8fbe-28d457fc388b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

